### PR TITLE
Improve confidence score display for a better accessibility

### DIFF
--- a/src/browser_action/css/_base.scss
+++ b/src/browser_action/css/_base.scss
@@ -108,13 +108,15 @@ strong {
     height: 8px;
     border-radius: 50%;
     margin-left: 3px;
+    border: 2px solid transparent;
 
     &.low-score {
-      background-color: $score-red;
+      border-color: $score-red;
     }
 
     &.average-score {
-      background-color: $score-yellow;
+      background: linear-gradient(0deg, $score-yellow, $score-yellow 45%, transparent 0, transparent);
+      border-color: $score-yellow;
     }
 
     &.high-score {


### PR DESCRIPTION
The confidence score is displayed as a dot with a color based on the score.
To improve accessibility, we change the displaying of confidence score, so the color is no more the only way to convey the information — colorblind people will appreciate it!

![image](https://user-images.githubusercontent.com/5339141/148066170-94d8c5ff-febb-4386-9cab-9c8ee2dda9bf.png)
