### PR TITLE
Create a build specific to Edge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 build-chrome.zip
 /build-firefox
 build-firefox.zip
+/build-edge
+build-edge.zip
 Archive.zip
 /node_modules
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Hunter's browser extension is an easy way to find email addresses from anywhere on the web, with just one click.
 
 * [Chrome Web Store](https://chrome.google.com/webstore/detail/hunter/hgmhmanijnjhaffoampdlllchpolkdnj)
+* [Add-on for Edge](https://microsoftedge.microsoft.com/addons/detail/hunter-email-finder-ext/dmgcgojogkfomifjfeeafajhmgilkofk)
 * [Add-on for Firefox](https://addons.mozilla.org/en-US/firefox/addon/hunterio/)
 
 [Hunter's API](https://hunter.io/api) is used to fetch the data and users' accounts information.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ On Chrome:
 2. Click **Load unpacked extension...**
 3. Select the folder `build-chrome`
 
+On Edge:
+
+1. Go to the extensions page (edge://extensions/)
+2. Click **Load unpacked**
+3. Select the folder `build-edge`
+
 On Firefox:
 
 1. Go to the debugging page (about:debugging)

--- a/config/_edge.js
+++ b/config/_edge.js
@@ -1,0 +1,63 @@
+module.exports.tasks = {
+  // Copy the build for Chrome before making the adaptations
+  copy: {
+    build_edge: {
+      expand: true,
+      cwd: "build-chrome/",
+      src: ["**"],
+      dest: "build-edge/"
+    }
+  },
+
+  // Do all the replacements to adapt from Chrome to Edge
+  replace: {
+    utm_parameters_edge: {
+      src: ["build-edge/**/*.js", "build-edge/**/*.html"],
+      overwrite: true,
+      replacements: [{
+        from: "utm_source=chrome_extension",
+        to: "utm_source=edge_addon"
+      },
+      {
+        from: "utm_medium=chrome_extension",
+        to: "utm_medium=edge_addon"
+      }]
+    },
+
+    website_welcome_url_edge: {
+      src: ["build-edge/**/*.js", "build-edge/**/*.html"],
+      overwrite: true,
+      replacements: [{
+        from: "/chrome/welcome",
+        to: "/edge/welcome"
+      }]
+    },
+
+    website_uninstall_url_edge: {
+      src: ["build-edge/**/*.js", "build-edge/**/*.html"],
+      overwrite: true,
+      replacements: [{
+        from: "/chrome/uninstall",
+        to: "/edge/uninstall"
+      }]
+    },
+
+    origin_header_edge: {
+      src: ["build-edge/**/*.js"],
+      overwrite: true,
+      replacements: [{
+        from: "\"Email-Hunter-Origin\": \"chrome_extension\"",
+        to: "\"Email-Hunter-Origin\": \"edge_addon\"",
+      }]
+    },
+
+    store_link_edge: {
+      src: ["build-edge/html/browser_popup.html"],
+      overwrite: true,
+      replacements: [{
+        from: "https://chrome.google.com/webstore/detail/email-hunter/hgmhmanijnjhaffoampdlllchpolkdnj/reviews",
+        to: "https://microsoftedge.microsoft.com/addons/detail/hunter-email-finder-ext/dmgcgojogkfomifjfeeafajhmgilkofk"
+      }]
+    }
+  }
+}

--- a/config/_firefox.js
+++ b/config/_firefox.js
@@ -1,7 +1,7 @@
 module.exports.tasks = {
   // Copy the build for Chrome before making the adaptations
   copy: {
-    build: {
+    build_firefox: {
       expand: true,
       cwd: "build-chrome/",
       src: ["**"],
@@ -11,7 +11,7 @@ module.exports.tasks = {
 
   // Do all the replacements to adapt from Chrome to Firefox
   replace: {
-    browser_api: {
+    browser_api_firefox: {
       src: ["build-firefox/**/*.js"],
       overwrite: true,
       replacements: [{
@@ -44,7 +44,7 @@ module.exports.tasks = {
       }]
     },
 
-    utm_parameters: {
+    utm_parameters_firefox: {
       src: ["build-firefox/**/*.js", "build-firefox/**/*.html"],
       overwrite: true,
       replacements: [{
@@ -57,7 +57,7 @@ module.exports.tasks = {
       }]
     },
 
-    website_welcome_url: {
+    website_welcome_url_firefox: {
       src: ["build-firefox/**/*.js", "build-firefox/**/*.html"],
       overwrite: true,
       replacements: [{
@@ -66,7 +66,7 @@ module.exports.tasks = {
       }]
     },
 
-    website_uninstall_url: {
+    website_uninstall_url_firefox: {
       src: ["build-firefox/**/*.js", "build-firefox/**/*.html"],
       overwrite: true,
       replacements: [{
@@ -75,16 +75,16 @@ module.exports.tasks = {
       }]
     },
 
-    origin_header: {
+    origin_header_firefox: {
       src: ["build-firefox/**/*.js"],
       overwrite: true,
       replacements: [{
         from: "\"Email-Hunter-Origin\": \"chrome_extension\"",
-        to: "\"Email-Hunter-Origin\": \"firefox_extension\"",
+        to: "\"Email-Hunter-Origin\": \"firefox_addon\"",
       }]
     },
 
-    store_link: {
+    store_link_firefox: {
       src: ["build-firefox/html/browser_popup.html"],
       overwrite: true,
       replacements: [{

--- a/config/watch.js
+++ b/config/watch.js
@@ -3,7 +3,7 @@ module.exports.tasks = {
   watch: {
     scripts: {
       files: ["src/**/*.js", "src/**/*.css", "src/**/*.scss", "src/**/*.html", "src/**/*.json", "src/**/*/*.coffee", "src/**/*/*.hbs"],
-      tasks: ["coffee", "handlebars", "compass", "cssmin", "copy", "replace", "editmanifestforfirefox"],
+      tasks: ["coffee", "handlebars", "compass", "cssmin", "copy", "replace"],
       options: {
         spawn: false,
       }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Hunter - Email Finder Extension",
   "short_name": "Hunter",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "manifest_version": 3,
   "description": "Find email addresses from anywhere on the web, with just one click.",
   "homepage_url": "https://hunter.io",


### PR DESCRIPTION
Hunter extension is now available natively on the Edge store!

This update creates small adaptations to make the extension unique to Edge. These changes are minor from the Chrome version since Edge is based on Chromium and Chrome extensions are compatible.