### PR TITLE
Check if a subdomain has emails before removing it

### DIFF
--- a/src/background/icon.coffee
+++ b/src/background/icon.coffee
@@ -13,8 +13,9 @@ LaunchColorChange = ->
     if tabArray[0]["url"] != window.currentDomain
       try
         hostname = new URL(tabArray[0]['url'])
-        window.currentDomain = Utilities.withoutSubDomain(hostname.host)
-        updateIconColor()
+        Utilities.findRelevantDomain hostname.host, (domain) ->
+          window.currentDomain = domain
+          updateIconColor()
       catch e
         # The tab is not a valid URL
         setGreyIcon()
@@ -28,20 +29,12 @@ updateIconColor = ->
   if window.currentDomain.indexOf(".") == -1
     setGreyIcon()
   else
-    chrome.storage.sync.get "hunter_blocked", (value) ->
-      if value["hunter_blocked"]
+    Utilities.dataFoundForDomain window.currentDomain, (results) ->
+      if results
         setColoredIcon()
       else
-        fetch("https://extension-api.hunter.io/data-for-domain?domain=" + window.currentDomain).then((response) ->
-          response.json()
-        ).then((response) ->
-          if response == 1
-            setColoredIcon()
-          else
-            setGreyIcon()
-        ).catch (error) ->
-          console.warn error
-          return
+        setGreyIcon()
+
 
 setGreyIcon = ->
   chrome.action.setIcon path:

--- a/src/browser_action/js/browser_action.coffee
+++ b/src/browser_action/js/browser_action.coffee
@@ -43,36 +43,38 @@ chrome.tabs.query {
 
     window.api_key = api_key
     window.url = tabs[0].url
-    window.domain = new URL(tabs[0].url).hostname.replace("www.", "")
 
-    # We clean the subdomain
-    window.domain = Utilities.withoutSubDomain(window.domain)
+    currentDomain = new URL(tabs[0].url).hostname
 
-    # We display a special message on LinkedIn
-    if window.domain == "linkedin.com"
-      $("#linkedin-notification").show()
-      $("#loading-placeholder").hide()
+    # We clean the subdomains when relevant
+    Utilities.findRelevantDomain currentDomain, (domain) ->
+      window.domain = domain
 
-    # We display a soft 404 if there is no domain name
-    else if window.domain == "" or window.domain.indexOf(".") == -1
-      $("#empty-notification").show()
-      $("#loading-placeholder").hide()
+      # We display a special message on LinkedIn
+      if window.domain == "linkedin.com"
+        $("#linkedin-notification").show()
+        $("#loading-placeholder").hide()
 
-    else
-      chrome.tabs.query {
-        active: true
-        currentWindow: true
-      }, (tabs) ->
-        chrome.tabs.sendMessage tabs[0].id, { parsing: "article" }, (response) ->
+      # We display a soft 404 if there is no domain name
+      else if window.domain == "" or window.domain.indexOf(".") == -1
+        $("#empty-notification").show()
+        $("#loading-placeholder").hide()
 
-          if response? && response.is_article
-            # Launch the Author Finder
-            authorFinder = new AuthorFinder
-            authorFinder.launch()
+      else
+        chrome.tabs.query {
+          active: true
+          currentWindow: true
+        }, (tabs) ->
+          chrome.tabs.sendMessage tabs[0].id, { parsing: "article" }, (response) ->
 
-            console.log("Author Finder launched")
+            if response? && response.is_article
+              # Launch the Author Finder
+              authorFinder = new AuthorFinder
+              authorFinder.launch()
 
-          else
-            # Launch the Domain Search
-            domainSearch = new DomainSearch
-            domainSearch.launch()
+              console.log("Author Finder launched")
+
+            else
+              # Launch the Domain Search
+              domainSearch = new DomainSearch
+              domainSearch.launch()

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Hunter - Email Finder Extension",
   "short_name": "Hunter",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "manifest_version": 3,
   "description": "Find email addresses from anywhere on the web, with just one click.",
   "homepage_url": "https://hunter.io",

--- a/src/shared/js/api.coffee
+++ b/src/shared/js/api.coffee
@@ -53,6 +53,10 @@ Api =
   leadsExist: (email, api_key) ->
     'https://api.hunter.io/v2/leads/exist?email=' + encodeURIComponent(email) + '&api_key=' + api_key
 
-  #Lead lists
+  # Leads lists
   leadsList: (api_key) ->
     'https://api.hunter.io/v2/leads_lists?limit=100&api_key=' + api_key
+
+  # Check if there is any email for a domain name
+  dataForDomain: (domain) ->
+    'https://extension-api.hunter.io/data-for-domain?domain=' + domain

--- a/src/shared/js/utilities.coffee
+++ b/src/shared/js/utilities.coffee
@@ -1,20 +1,64 @@
 Utilities =
-  # Remove all the subdomains
-  withoutSubDomain: (domain) ->
+  # Return a decomposition of all successive subdomains in an array
+  # In some rare case, this function might remove the main domain name and let only the
+  # TLD. To mitigate these cases, we check if we can find emails by adding back one level
+  # in the function "findRelevantDomain".
+  #
+  decomposeSubDomains: (domain) ->
+    domains = [domain]
+
     loop
-      newdomain = domain.substring(domain.indexOf('.') + 1)
-      subdomainsCount = (newdomain.match(/\./g) or []).length
+      newDomain = domain.substring(domain.indexOf('.') + 1)
+      subdomainsCount = (newDomain.match(/\./g) or []).length
 
-      if (subdomainsCount == 0 || newdomain.length <= 7) then break
-      domain = newdomain
+      if (subdomainsCount == 0 || newDomain.length <= 7) then break
+      domain = newDomain
+      domains.push newDomain
 
-    return domain
+    return domains
+
+  # This function decides if it's relevant to remove the highest found subdomain or not.
+  # If we find data by keeping the subdomain, this is the domain we will use.
+  #
+  findRelevantDomain: (domain, fn) ->
+    # In any case, we won't try emails on domain starting with "www."
+    domain = domain.replace(/^www\./i, "")
+
+    domains = @decomposeSubDomains(domain)
+
+    return fn(domain) if domains.length == 1
+
+    withSubdomain = domains[domains.length - 2]
+    withoutSubdomain = domains.pop()
+
+    @dataFoundForDomain withSubdomain, (results) ->
+      if results
+        return fn(withSubdomain)
+      else
+        return fn(withoutSubdomain)
+
+  # Check if we have data for the given domain name, by using a dedicated API endpoint.
+  #
+  dataFoundForDomain: (domain, fn) ->
+    fetch(Api.dataForDomain(domain)).then((response) ->
+      response.json()
+    ).then((response) ->
+      if response == 1
+        fn(true)
+      else
+        fn(false)
+    ).catch (error) ->
+      console.warn error
+      fn(false)
+
 
   # Add commas separating thousands
+  #
   numberWithCommas: (x) ->
     x.toString().replace /\B(?=(\d{3})+(?!\d))/g, ','
 
   # Display dates easy to read
+  #
   dateInWords: (input) ->
     date = undefined
     monthNames = undefined
@@ -57,6 +101,7 @@ Utilities =
     return string.charAt(0).toUpperCase() + string.slice(1)
 
   # Open in a new tab
+  #
   openInNewTab: (url) ->
     win = window.open(url, '_blank')
     win.focus()
@@ -136,7 +181,8 @@ Utilities =
 
     return sortable
 
-
+  # Converts to MD5
+  #
   MD5: (s) ->
     C = Array()
     P = undefined
@@ -354,8 +400,8 @@ Utilities =
     i = B(Y) + B(X) + B(W) + B(V)
     i.toLowerCase()
 
-
 # Generate a hash from a string
+#
 String::hashCode = ->
   hash = 0
   i = undefined


### PR DESCRIPTION
There are some edge cases where the domain is reduced to find emails, but shouldn't. For example, https://www.bodsham.kent.sch.uk/Contact-Us/. 

The extension was reducing the domain to `kent.sch.uk`, but the domain is actually `bodsham.kent.sch.uk`. To maximize the chances to find emails, it will also double-check if we can find anything by adding the left side that was removed (be it a subdomain or mistakenly the main domain like in this example).