### PR TITLE
Increase width + go under head and footer bars

### DIFF
--- a/src/browser_action/css/_search.scss
+++ b/src/browser_action/css/_search.scss
@@ -11,7 +11,7 @@
   background-color: var(--colors-grey-900);
   color: #fff;
   min-height: 5.2rem;
-  z-index: 100;
+  z-index: 1001;
 }
 
 .header__logo {
@@ -81,7 +81,6 @@
 }
 
 .account-upgrade-cta {
-  display: inline;
   margin: 0 var(--spacing-01) 0 var(--spacing-02);
 }
 
@@ -266,6 +265,7 @@
   border: 1px solid var(--colors-grey-300);
   border-radius: 4px;
   overflow: hidden;
+  min-width: 19rem;
 
   &:lang(fr) {
     min-width: 21rem;

--- a/src/browser_action/css/_search.scss
+++ b/src/browser_action/css/_search.scss
@@ -156,7 +156,7 @@
   background: #FFFFFF;
   border-top: 1px solid var(--colors-grey-300);
   box-shadow: 0px -6px 12px rgba(0, 0, 0, 0.04);
-  z-index: 90;
+  z-index: 1001;
 }
 
 .list-select-container {


### PR DESCRIPTION
Small CSS fix for the dropdowns:

- Make it larger to avoid break lines with the new department filters
- Make it go under the header bar or the footer when the scroll is used