### PR TITLE
Improves global experience

### DIFF
--- a/src/browser_action/css/_base.scss
+++ b/src/browser_action/css/_base.scss
@@ -7,7 +7,7 @@
 
 html {
   width: 620px;
-  min-height: 480px;
+  min-height: 520px;
   position: relative;
 }
 

--- a/src/browser_action/css/_search.scss
+++ b/src/browser_action/css/_search.scss
@@ -296,7 +296,7 @@
   list-style-type: none;
   padding: var(--spacing-04);
   margin: 0;
-  max-height: 29rem;
+  max-height: 24rem;
   overflow: auto;
 }
 
@@ -327,6 +327,7 @@
 }
 
 .filters__by-name {
+  display: none;
   margin-left: auto;
 
   &[aria-expanded="true"] {

--- a/src/browser_action/css/_search.scss
+++ b/src/browser_action/css/_search.scss
@@ -545,8 +545,16 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  user-select: all;
-  cursor: pointer;
+  user-select: none;
+
+  &.copy-email {
+    user-select: all;
+    cursor: pointer;
+  }
+
+  span {
+    filter: blur(4px);
+  }
 }
 
 .ds-result__verification {

--- a/src/browser_action/css/_search.scss
+++ b/src/browser_action/css/_search.scss
@@ -327,7 +327,6 @@
 }
 
 .filters__by-name {
-  display: none;
   margin-left: auto;
 
   &[aria-expanded="true"] {
@@ -433,15 +432,6 @@
   max-width: 50%;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.ds-finder-form-company__domain {
-  margin-left: auto;
-  text-align: right;
-  font-size: 1.2rem;
-  font-weight: 500;
-  line-height: calc(20/12);
-  color: var(--colors-grey-600);
 }
 
 .ds-finder-form__submit {

--- a/src/browser_action/js/domain_search.coffee
+++ b/src/browser_action/js/domain_search.coffee
@@ -123,20 +123,18 @@ DomainSearch = ->
       if @results_count == 1 then s = "" else s = "s"
       $("#domain-search .results-header__count").html chrome.i18n.getMessage("results_for_domain", [DOMPurify.sanitize(Utilities.numberWithCommas(@results_count)), s, DOMPurify.sanitize(@domain)])
 
-      # Display: the email pattern if any, with the Email Finder form
+      # Display: the email pattern if any
       if @pattern != null
-        $(".filters__by-name").show()
         $(".results-header__pattern").show()
         $(".results-header__pattern strong").html(@addPatternTitle(@pattern) + "@" + @domain)
         $("[data-toggle='tooltip']").tooltip()
 
-        # Email Finder
-        $(".ds-finder-form-company__name").text @organization
-        $(".ds-finder-form-company__domain").text @domain
-        $(".ds-finder-form-company__logo").attr "src", "https://logo.clearbit.com/" + @domain
-        @openFindbyName()
-        emailFinder = new EmailFinder
-        emailFinder.validateForm()
+      # Email Finder
+      $(".ds-finder-form-company__name").text @organization
+      $(".ds-finder-form-company__logo").attr "src", "https://logo.clearbit.com/" + @domain
+      emailFinder = new EmailFinder
+      emailFinder.validateForm()
+      @openFindbyName()
 
       # Display: the updated number of requests
       loadAccountInformation()

--- a/src/browser_action/js/domain_search.coffee
+++ b/src/browser_action/js/domain_search.coffee
@@ -219,10 +219,10 @@ DomainSearch = ->
         lead.disableSaveLeadButtonIfLeadExists(save_lead_button)
 
         # Hide beautifully if the user is not logged
-        unless _this.trial
+        if _this.trial
           result_tag.find(".ds-result__email").removeClass("copy-email")
           result_tag.find(".ds-result__email").attr("title", chrome.i18n.getMessage("sign_up_to_uncover_more_emails"))
-          result_tag.find(".ds-result__email").html result_tag.find(".ds-result__email").text().replace("info", "<span>aaa</span>")
+          result_tag.find(".ds-result__email").html result_tag.find(".ds-result__email").text().replace("**", "<span>aaa</span>")
 
       @openSources()
       $(".search-results").show()

--- a/src/browser_action/js/domain_search.coffee
+++ b/src/browser_action/js/domain_search.coffee
@@ -219,10 +219,10 @@ DomainSearch = ->
         lead.disableSaveLeadButtonIfLeadExists(save_lead_button)
 
         # Hide beautifully if the user is not logged
-        if _this.trial
+        unless _this.trial
           result_tag.find(".ds-result__email").removeClass("copy-email")
-          result_tag.find(".ds-result__email").attr("title", chrome.i18n.getMessage("sign_up_to_uncover"))
-          result_tag.find(".ds-result__email").html result_tag.find(".ds-result__email").text().replace("**", "<span>aaa</span>")
+          result_tag.find(".ds-result__email").attr("title", chrome.i18n.getMessage("sign_up_to_uncover_more_emails"))
+          result_tag.find(".ds-result__email").html result_tag.find(".ds-result__email").text().replace("info", "<span>aaa</span>")
 
       @openSources()
       $(".search-results").show()

--- a/src/browser_action/js/domain_search.coffee
+++ b/src/browser_action/js/domain_search.coffee
@@ -219,7 +219,10 @@ DomainSearch = ->
         lead.disableSaveLeadButtonIfLeadExists(save_lead_button)
 
         # Hide beautifully if the user is not logged
-        result_tag.find(".email").html result_tag.find(".email").text().replace("**", "<span data-toggle='tooltip' data-placement='top' title='" + chrome.i18n.getMessage("sign_up_to_uncover") + "'>aa</span>")
+        if _this.trial
+          result_tag.find(".ds-result__email").removeClass("copy-email")
+          result_tag.find(".ds-result__email").attr("title", chrome.i18n.getMessage("sign_up_to_uncover"))
+          result_tag.find(".ds-result__email").html result_tag.find(".ds-result__email").text().replace("**", "<span>aaa</span>")
 
       @openSources()
       $(".search-results").show()

--- a/src/browser_action/popup.html
+++ b/src/browser_action/popup.html
@@ -680,12 +680,14 @@
         <div class="search-results ds-results"></div>
       </div>
 
-      <footer class="leads-manager account-logged">
-        <div class="list-select-container">
-          <label data-locale="save_leads_in" for="leads-list">Save leads in</label>
-        </div>
-        <a data-locale="go_to_my_leads" class="leads-manager__link" target="blank" href="https://hunter.io/leads?utm_source=chrome_extension&utm_medium=chrome_extension&utm_campaign=extension&utm_content=browser_popup">Go to my leads</a>
-      </footer>
+      <div class="account-logged">
+        <footer class="leads-manager">
+          <div class="list-select-container">
+            <label data-locale="save_leads_in" for="leads-list">Save leads in</label>
+          </div>
+          <a data-locale="go_to_my_leads" class="leads-manager__link" target="blank" href="https://hunter.io/leads?utm_source=chrome_extension&utm_medium=chrome_extension&utm_campaign=extension&utm_content=browser_popup">Go to my leads</a>
+        </footer>
+      </div>
     </div>
 
     <!-- Global errors / Empty states -->

--- a/src/browser_action/popup.html
+++ b/src/browser_action/popup.html
@@ -479,7 +479,6 @@
               <div class="ds-finder-form-company">
                 <img class="ds-finder-form-company__logo" alt="">
                 <span class="ds-finder-form-company__name"></span>
-                <strong class="ds-finder-form-company__domain"></strong>
               </div>
               <button aria-label="Find this person" class="ds-finder-form__submit" type="submit">
                 <span class="far fa-search"></span>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_extension_name__",
   "short_name": "Hunter",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "manifest_version": 3,
   "description": "__MSG_extension_description__",
   "homepage_url": "https://hunter.io",


### PR DESCRIPTION
This PR improves the global experience:
- Keep the "Find by name" button when there's no email pattern
- Remove the domain name from the Email Finder form (not needed and create layout issues on long names)
- If not logged: blur the email (`**`) and remove click to copy feature
- If not logged: hide the list manager